### PR TITLE
Fix sync to use new `RawData` field

### DIFF
--- a/sync-data/main.go
+++ b/sync-data/main.go
@@ -92,7 +92,7 @@ func main() {
 		logger.Fatalw("error querying source data", "error", err)
 	}
 
-	if len(tabularDataByMQLResponse.Data) == 0 {
+	if len(tabularDataByMQLResponse.RawData) == 0 {
 		logger.Fatal("Zero documents returned from TabularDataByMQL")
 	}
 


### PR DESCRIPTION
AFAIK, TabularDataByMQL is not packaged by golang sdk so we have to use the raw client.